### PR TITLE
Update where clause docs to have brackets

### DIFF
--- a/docs/api/model/where.md
+++ b/docs/api/model/where.md
@@ -25,7 +25,7 @@ With this syntax, the list is expanded in-situ and each list item is defined as 
 
 ```javascript
 let adminUsers = await User.find({}, {
-    where: '(${role} IN @{...roles})',
+    where: '(${role} IN (@{...roles}))',
     substitutions: {
         roles: ['user', 'admin']
     }


### PR DESCRIPTION
We found recently that the syntax for one of the where clause examples wan't quite right, just a quick fix.